### PR TITLE
Added persistant searchbar, created page transitions

### DIFF
--- a/index.html
+++ b/index.html
@@ -45,7 +45,7 @@
                 Clear save data
             </button>
 
-            <h1 style="text-align: center; cursor: pointer; margin-bottom: 0px;" @click="navigateTo('')">
+            <h1 style="text-align: center; cursor: pointer; margin-bottom: 0px;" @click="navigateTo(''); searchQuery='';">
                 Infinite Craft Wiki
             </h1>
             

--- a/index.html
+++ b/index.html
@@ -65,7 +65,7 @@
                     <div style="display: flex; flex-direction: row; justify-content: space-between;">
                         <button
                             style="background-color: #347d39; color:#c6c7c7; text-decoration: none; border-radius: 0.5rem; padding: 0.5rem 1rem; cursor: pointer; display: flex; flex-direction: row; align-items: center; gap: 1rem; border: none"
-                            onclick="window.open('https://github.com/expitau/InfiniteCraftWiki', '_blank').focus()">
+                            onclick="window.open('github.com/expitau/InfiniteCraftWiki', '_blank').focus()">
                             <span>Sure!</span>
                             <svg viewBox="0 0 16 16" aria-hidden="true" width="24" height="24" fill="currentColor">
                                 <path fill="currentColor"
@@ -96,36 +96,60 @@
                         <transition :name="slideTransition" mode="out-in">
                             <table :key="currentElement">
                                 <tr v-for="recipe in currentFrom">
-                                    <td class="item" :class="{'item-used': !saveData.includes(recipe.A)}"
-                                        @click="navigateTo(recipe.A); slideTransition='slide-right';">
-                                        {{ data.index[recipe.A][0] }}&nbsp;{{ data.index[recipe.A][1] }}
+                                    <td class="table-cell">
+                                        <div class="item item-wrapper" :class="{'item-used': !saveData.includes(recipe.A)}"
+                                            @click="navigateTo(recipe.A); slideTransition='slide-right';">
+                                            <div class="item-emoji">{{ data.index[recipe.A][0] }}</div>
+                                            &nbsp;
+                                            <div class="item-text">{{ data.index[recipe.A][1] }}</div>
+                                        </div>
                                     </td>
                                     <td>+</td>
-                                    <td class="item" :class="{'item-used': !saveData.includes(recipe.B)}"
-                                        @click="navigateTo(recipe.B); slideTransition='slide-right';">
-                                        {{ data.index[recipe.B][0] }}&nbsp;{{ data.index[recipe.B][1] }}
+                                    <td class="table-cell">
+                                        <div class="item item-wrapper" :class="{'item-used': !saveData.includes(recipe.B)}"
+                                            @click="navigateTo(recipe.B); slideTransition='slide-right';">
+                                            <div class="item-emoji">{{ data.index[recipe.B][0] }}</div>
+                                            &nbsp;
+                                            <div class="item-text">{{ data.index[recipe.B][1] }}</div>
+                                        </div>
                                     </td>
                                     <td>=</td>
-                                    <td class="item" :class="{'item-used': !saveData.includes(recipe.C)}"
-                                        @click="navigateTo(recipe.C); slideTransition='slide-right';">
-                                        {{ data.index[recipe.C][0] }}&nbsp;{{ data.index[recipe.C][1] }}
+                                    <td class="table-cell">
+                                        <div class="item item-wrapper" :class="{'item-used': !saveData.includes(recipe.C)}"
+                                            @click="navigateTo(recipe.C); slideTransition='slide-right';">
+                                            <div class="item-emoji">{{ data.index[recipe.C][0] }}</div>
+                                            &nbsp;
+                                            <div class="item-text">{{ data.index[recipe.C][1] }}</div>
+                                        </div>
                                     </td>
                                 </tr>
 
                                 <tr v-for="recipe in currentHiddenFrom" v-if="showHiddenRecipes">
-                                    <td class="item" :class="{'item-used': !saveData.includes(recipe.A)}"
-                                        @click="navigateTo(recipe.A); slideTransition='slide-right';">
-                                        {{ data.index[recipe.A][0] }}&nbsp;{{ data.index[recipe.A][1] }}
+                                    <td class="table-cell">
+                                        <div class="item item-wrapper" :class="{'item-used': !saveData.includes(recipe.A)}"
+                                            @click="navigateTo(recipe.A); slideTransition='slide-right';">
+                                            <div class="item-emoji">{{ data.index[recipe.A][0] }}</div>
+                                            &nbsp;
+                                            <div class="item-text">{{ data.index[recipe.A][1] }}</div>
+                                        </div>
                                     </td>
                                     <td>+</td>
-                                    <td class="item" :class="{'item-used': !saveData.includes(recipe.B)}"
-                                        @click="navigateTo(recipe.B); slideTransition='slide-right';">
-                                        {{ data.index[recipe.B][0] }}&nbsp;{{ data.index[recipe.B][1] }}
+                                    <td class="table-cell">
+                                        <div class="item item-wrapper" :class="{'item-used': !saveData.includes(recipe.B)}"
+                                            @click="navigateTo(recipe.B); slideTransition='slide-right';">
+                                            <div class="item-emoji">{{ data.index[recipe.B][0] }}</div>
+                                            &nbsp;
+                                            <div class="item-text">{{ data.index[recipe.B][1] }}</div>
+                                        </div>
                                     </td>
                                     <td>=</td>
-                                    <td class="item" :class="{'item-used': !saveData.includes(recipe.C)}"
-                                        @click="navigateTo(recipe.C); slideTransition='slide-right';">
-                                        {{ data.index[recipe.C][0] }}&nbsp;{{ data.index[recipe.C][1] }}
+                                    <td class="table-cell">
+                                        <div class="item item-wrapper" :class="{'item-used': !saveData.includes(recipe.C)}"
+                                            @click="navigateTo(recipe.C); slideTransition='slide-right';">
+                                            <div class="item-emoji">{{ data.index[recipe.C][0] }}</div>
+                                            &nbsp;
+                                            <div class="item-text">{{ data.index[recipe.C][1] }}</div>
+                                        </div>
                                     </td>
                                 </tr>
                             </table>
@@ -145,36 +169,60 @@
                         <transition :name="slideTransition" mode="out-in">
                             <table :key="currentElement">
                                 <tr v-for="recipe in currentTo">
-                                    <td class="item" :class="{'item-used': !saveData.includes(recipe.A)}"
-                                        @click="navigateTo(recipe.A); slideTransition='slide-left';">
-                                        {{ data.index[recipe.A][0] }}&nbsp;{{ data.index[recipe.A][1] }}
+                                    <td class="table-cell">
+                                        <div class="item item-wrapper" :class="{'item-used': !saveData.includes(recipe.A)}"
+                                            @click="navigateTo(recipe.A); slideTransition='slide-right';">
+                                            <div class="item-emoji">{{ data.index[recipe.A][0] }}</div>
+                                            &nbsp;
+                                            <div class="item-text">{{ data.index[recipe.A][1] }}</div>
+                                        </div>
                                     </td>
                                     <td>+</td>
-                                    <td class="item" :class="{'item-used': !saveData.includes(recipe.B)}"
-                                        @click="navigateTo(recipe.B); slideTransition='slide-left';">
-                                        {{ data.index[recipe.B][0] }}&nbsp;{{ data.index[recipe.B][1] }}
+                                    <td class="table-cell">
+                                        <div class="item item-wrapper" :class="{'item-used': !saveData.includes(recipe.B)}"
+                                            @click="navigateTo(recipe.B); slideTransition='slide-right';">
+                                            <div class="item-emoji">{{ data.index[recipe.B][0] }}</div>
+                                            &nbsp;
+                                            <div class="item-text">{{ data.index[recipe.B][1] }}</div>
+                                        </div>
                                     </td>
                                     <td>=</td>
-                                    <td class="item" :class="{'item-used': !saveData.includes(recipe.C)}"
-                                        @click="navigateTo(recipe.C); slideTransition='slide-left';">
-                                        {{ data.index[recipe.C][0] }}&nbsp;{{ data.index[recipe.C][1] }}
+                                    <td class="table-cell">
+                                        <div class="item item-wrapper" :class="{'item-used': !saveData.includes(recipe.C)}"
+                                            @click="navigateTo(recipe.C); slideTransition='slide-right';">
+                                            <div class="item-emoji">{{ data.index[recipe.C][0] }}</div>
+                                            &nbsp;
+                                            <div class="item-text">{{ data.index[recipe.C][1] }}</div>
+                                        </div>
                                     </td>
                                 </tr>
 
                                 <tr v-for="recipe in currentHiddenTo" v-if="showHiddenRecipes">
-                                    <td class="item" :class="{'item-used': !saveData.includes(recipe.A)}"
-                                        @click="navigateTo(recipe.A); slideTransition='slide-left';">
-                                        {{ data.index[recipe.A][0] }}&nbsp;{{ data.index[recipe.A][1] }}
+                                    <td class="table-cell">
+                                        <div class="item item-wrapper" :class="{'item-used': !saveData.includes(recipe.A)}"
+                                            @click="navigateTo(recipe.A); slideTransition='slide-right';">
+                                            <div class="item-emoji">{{ data.index[recipe.A][0] }}</div>
+                                            &nbsp;
+                                            <div class="item-text">{{ data.index[recipe.A][1] }}</div>
+                                        </div>
                                     </td>
                                     <td>+</td>
-                                    <td class="item" :class="{'item-used': !saveData.includes(recipe.B)}"
-                                        @click="navigateTo(recipe.B); slideTransition='slide-left';">
-                                        {{ data.index[recipe.B][0] }}&nbsp;{{ data.index[recipe.B][1] }}
+                                    <td class="table-cell">
+                                        <div class="item item-wrapper" :class="{'item-used': !saveData.includes(recipe.B)}"
+                                            @click="navigateTo(recipe.B); slideTransition='slide-right';">
+                                            <div class="item-emoji">{{ data.index[recipe.B][0] }}</div>
+                                            &nbsp;
+                                            <div class="item-text">{{ data.index[recipe.B][1] }}</div>
+                                        </div>
                                     </td>
                                     <td>=</td>
-                                    <td class="item" :class="{'item-used': !saveData.includes(recipe.C)}"
-                                        @click="navigateTo(recipe.C); slideTransition='slide-left';">
-                                        {{ data.index[recipe.C][0] }}&nbsp;{{ data.index[recipe.C][1] }}
+                                    <td class="table-cell">
+                                        <div class="item item-wrapper" :class="{'item-used': !saveData.includes(recipe.C)}"
+                                            @click="navigateTo(recipe.C); slideTransition='slide-right';">
+                                            <div class="item-emoji">{{ data.index[recipe.C][0] }}</div>
+                                            &nbsp;
+                                            <div class="item-text">{{ data.index[recipe.C][1] }}</div>
+                                        </div>
                                     </td>
                                 </tr>
                             </table>

--- a/index.html
+++ b/index.html
@@ -50,18 +50,7 @@
             </h1>
             
             <h3 class="sub-header">
-                {{
-                !Object.keys(data.index).length ?
-                "#####" :
-                (Object.keys(data.index).length - 1).toString().replace(/\B(?=(\d{3})+(?!\d))/g, ',')
-                }}
-                elements -
-                {{
-                !Object.keys(data.index).length ?
-                "#####" :
-                data.recipeCount.toString().replace(/\B(?=(\d{3})+(?!\d))/g, ',')
-                }}
-                recipes
+                {{ elementAndRecipeCount }}
             </h3>
 
             <div class="search-bar-wrapper">
@@ -389,24 +378,38 @@
                     let list = Object.keys(this.data.index).sort((a, b) => this.data.costs[a] - this.data.costs[b]).filter(x => this.data.index[x][1] != "Nothing")
                     return list.filter(x => this.data.index[x][1].toLowerCase().includes(this.searchQuery.toLowerCase())).slice(0, this.loaded)
                 },
+                elementAndRecipeCount: function() {
+                    let elementCount = "#####";
+                    let recipeCount = "######";
+
+                    if(Object.keys(this.data.index).length != 0){
+                        elementCount = this.formatNumAsString(Object.keys(this.data.index).length - 1);
+                        recipeCount = this.formatNumAsString(this.data.recipeCount);
+                    }
+
+                    return `${elementCount} elements - ${recipeCount} recipes`;
+                }
             },
             methods: {
+                formatNumAsString: function(number){
+                    return number.toString().replace(/\B(?=(\d{3})+(?!\d))/g, ',');
+                },
                 navigateTo: function (element) {
-                    this.currentElement = element
-                    this.showHiddenRecipes = false
-                    setQuery({ e: this.currentElement })
-                    return this.currentElement ? this.currentElement : ""
+                    this.currentElement = element;
+                    this.showHiddenRecipes = false;
+                    setQuery({ e: this.currentElement });
+                    return this.currentElement ? this.currentElement : "";
                 },
                 addScrollPage: function () {
-                    this.loaded += 500
+                    this.loaded += 500;
                 },
                 clearSaveData: function () {
-                    this.saveData = []
-                    localStorage.setItem("saveData", "")
+                    this.saveData = [];
+                    localStorage.setItem("saveData", "");
                 }
             },
             mounted() {
-                this.showToast = JSON.parse(localStorage.getItem("showToast")) ?? true
+                this.showToast = JSON.parse(localStorage.getItem("showToast")) ?? true;
                 // Load recipes from JSON file
                 fetch('data.json')
                     .then(response => { console.log(response); return response.json() })
@@ -429,7 +432,7 @@
                     var pageOffset = window.pageYOffset + window.innerHeight;
 
                     if (pageOffset > lastDivOffset - 20) {
-                        app.addScrollPage()
+                        app.addScrollPage();
                     }
                 });
             }

--- a/index.html
+++ b/index.html
@@ -38,10 +38,35 @@
                 </svg>
                 <div class="github-link-text">Star my repo!</div>
             </a>
+
             <button
                 style="background-color: #347d39; color:#c6c7c7; text-decoration: none; border-radius: 0.5rem; padding: 0.5rem 1rem; cursor: pointer;  border: none; position: absolute; top: 0; right: 0; margin: 1rem"
-                @click="clearSaveData()" v-if="saveData.length > 0">Clear save data</button>
-            <h1 style="text-align: center; cursor: pointer;" @click="navigateTo('')">Infinite Craft Wiki</h1>
+                @click="clearSaveData()" v-if="saveData.length > 0">
+                Clear save data
+            </button>
+
+            <h1 style="text-align: center; cursor: pointer; margin-bottom: 0px;" @click="navigateTo('')">
+                Infinite Craft Wiki
+            </h1>
+            
+            <h3 class="sub-header">
+                {{
+                !Object.keys(data.index).length ?
+                "#####" :
+                (Object.keys(data.index).length - 1).toString().replace(/\B(?=(\d{3})+(?!\d))/g, ',')
+                }}
+                elements -
+                {{
+                !Object.keys(data.index).length ?
+                "#####" :
+                data.recipeCount.toString().replace(/\B(?=(\d{3})+(?!\d))/g, ',')
+                }}
+                recipes
+            </h3>
+
+            <div class="search-bar-wrapper">
+                <input class="search-bar" type="text" placeholder="Search..." v-model="searchQuery" @click="navigateTo('')"></input>
+            </div>
 
             <div class="toast" v-if="showToast">
                 <div class="toast-body">
@@ -67,50 +92,55 @@
                     </div>
                 </div>
             </div>
-            <div v-if="currentElement">
-                <h2 style="text-align: center;">
-                    <div class="item" style=" padding: 13px 15px 12px" @click="navigateTo('')">
-                        {{ data.index[currentElement][0] }}&nbsp;{{ data.index[currentElement][1] }}
-                    </div>
-                </h2>
+            <transition name="slide-up" mode="out-in">
+            <div key=0 v-if="currentElement">
+                <transition :name="slideTransition" mode="out-in">
+                    <h2 :key="currentElement" style="text-align: center;">
+                        <div class="item" style=" padding: 13px 15px 12px">
+                            {{ data.index[currentElement][0] }}&nbsp;{{ data.index[currentElement][1] }}
+                        </div>
+                    </h2>
+                </transition>
                 <div class="ingredients-flex">
                     <div class="ingredients-list">
                         <h3>Created by</h3>
-                        <table>
-                            <tr v-for="recipe in currentFrom">
-                                <td class="item" :class="{'item-used': !saveData.includes(recipe.A)}"
-                                    @click="navigateTo(recipe.A)">
-                                    {{ data.index[recipe.A][0] }}&nbsp;{{ data.index[recipe.A][1] }}
-                                </td>
-                                <td>+</td>
-                                <td class="item" :class="{'item-used': !saveData.includes(recipe.B)}"
-                                    @click="navigateTo(recipe.B)">
-                                    {{ data.index[recipe.B][0] }}&nbsp;{{ data.index[recipe.B][1] }}
-                                </td>
-                                <td>=</td>
-                                <td class="item" :class="{'item-used': !saveData.includes(recipe.C)}"
-                                    @click="navigateTo(recipe.C)">
-                                    {{ data.index[recipe.C][0] }}&nbsp;{{ data.index[recipe.C][1] }}
-                                </td>
-                            </tr>
+                        <transition :name="slideTransition" mode="out-in">
+                            <table :key="currentElement">
+                                <tr v-for="recipe in currentFrom">
+                                    <td class="item" :class="{'item-used': !saveData.includes(recipe.A)}"
+                                        @click="navigateTo(recipe.A); slideTransition='slide-right';">
+                                        {{ data.index[recipe.A][0] }}&nbsp;{{ data.index[recipe.A][1] }}
+                                    </td>
+                                    <td>+</td>
+                                    <td class="item" :class="{'item-used': !saveData.includes(recipe.B)}"
+                                        @click="navigateTo(recipe.B); slideTransition='slide-right';">
+                                        {{ data.index[recipe.B][0] }}&nbsp;{{ data.index[recipe.B][1] }}
+                                    </td>
+                                    <td>=</td>
+                                    <td class="item" :class="{'item-used': !saveData.includes(recipe.C)}"
+                                        @click="navigateTo(recipe.C); slideTransition='slide-right';">
+                                        {{ data.index[recipe.C][0] }}&nbsp;{{ data.index[recipe.C][1] }}
+                                    </td>
+                                </tr>
 
-                            <tr v-for="recipe in currentHiddenFrom" v-if="showHiddenRecipes">
-                                <td class="item" :class="{'item-used': !saveData.includes(recipe.A)}"
-                                    @click="navigateTo(recipe.A)">
-                                    {{ data.index[recipe.A][0] }}&nbsp;{{ data.index[recipe.A][1] }}
-                                </td>
-                                <td>+</td>
-                                <td class="item" :class="{'item-used': !saveData.includes(recipe.B)}"
-                                    @click="navigateTo(recipe.B)">
-                                    {{ data.index[recipe.B][0] }}&nbsp;{{ data.index[recipe.B][1] }}
-                                </td>
-                                <td>=</td>
-                                <td class="item" :class="{'item-used': !saveData.includes(recipe.C)}"
-                                    @click="navigateTo(recipe.C)">
-                                    {{ data.index[recipe.C][0] }}&nbsp;{{ data.index[recipe.C][1] }}
-                                </td>
-                            </tr>
-                        </table>
+                                <tr v-for="recipe in currentHiddenFrom" v-if="showHiddenRecipes">
+                                    <td class="item" :class="{'item-used': !saveData.includes(recipe.A)}"
+                                        @click="navigateTo(recipe.A); slideTransition='slide-right';">
+                                        {{ data.index[recipe.A][0] }}&nbsp;{{ data.index[recipe.A][1] }}
+                                    </td>
+                                    <td>+</td>
+                                    <td class="item" :class="{'item-used': !saveData.includes(recipe.B)}"
+                                        @click="navigateTo(recipe.B); slideTransition='slide-right';">
+                                        {{ data.index[recipe.B][0] }}&nbsp;{{ data.index[recipe.B][1] }}
+                                    </td>
+                                    <td>=</td>
+                                    <td class="item" :class="{'item-used': !saveData.includes(recipe.C)}"
+                                        @click="navigateTo(recipe.C); slideTransition='slide-right';">
+                                        {{ data.index[recipe.C][0] }}&nbsp;{{ data.index[recipe.C][1] }}
+                                    </td>
+                                </tr>
+                            </table>
+                        </transition>
                         <div v-if="currentHiddenFrom.length > 0">
                             <div v-if="!showHiddenRecipes" class="text-link" @click="showHiddenRecipes = true">
                                 {{currentHiddenFrom.length}} entries hidden
@@ -123,42 +153,44 @@
 
                     <div class="ingredients-list">
                         <h3>Used in</h3>
-                        <table>
-                            <tr v-for="recipe in currentTo">
-                                <td class="item" :class="{'item-used': !saveData.includes(recipe.A)}"
-                                    @click="navigateTo(recipe.A)">
-                                    {{ data.index[recipe.A][0] }}&nbsp;{{ data.index[recipe.A][1] }}
-                                </td>
-                                <td>+</td>
-                                <td class="item" :class="{'item-used': !saveData.includes(recipe.B)}"
-                                    @click="navigateTo(recipe.B)">
-                                    {{ data.index[recipe.B][0] }}&nbsp;{{ data.index[recipe.B][1] }}
-                                </td>
-                                <td>=</td>
-                                <td class="item" :class="{'item-used': !saveData.includes(recipe.C)}"
-                                    @click="navigateTo(recipe.C)">
-                                    {{ data.index[recipe.C][0] }}&nbsp;{{ data.index[recipe.C][1] }}
-                                </td>
-                            </tr>
+                        <transition :name="slideTransition" mode="out-in">
+                            <table :key="currentElement">
+                                <tr v-for="recipe in currentTo">
+                                    <td class="item" :class="{'item-used': !saveData.includes(recipe.A)}"
+                                        @click="navigateTo(recipe.A); slideTransition='slide-left';">
+                                        {{ data.index[recipe.A][0] }}&nbsp;{{ data.index[recipe.A][1] }}
+                                    </td>
+                                    <td>+</td>
+                                    <td class="item" :class="{'item-used': !saveData.includes(recipe.B)}"
+                                        @click="navigateTo(recipe.B); slideTransition='slide-left';">
+                                        {{ data.index[recipe.B][0] }}&nbsp;{{ data.index[recipe.B][1] }}
+                                    </td>
+                                    <td>=</td>
+                                    <td class="item" :class="{'item-used': !saveData.includes(recipe.C)}"
+                                        @click="navigateTo(recipe.C); slideTransition='slide-left';">
+                                        {{ data.index[recipe.C][0] }}&nbsp;{{ data.index[recipe.C][1] }}
+                                    </td>
+                                </tr>
 
-                            <tr v-for="recipe in currentHiddenTo" v-if="showHiddenRecipes">
-                                <td class="item" :class="{'item-used': !saveData.includes(recipe.A)}"
-                                    @click="navigateTo(recipe.A)">
-                                    {{ data.index[recipe.A][0] }}&nbsp;{{ data.index[recipe.A][1] }}
-                                </td>
-                                <td>+</td>
-                                <td class="item" :class="{'item-used': !saveData.includes(recipe.B)}"
-                                    @click="navigateTo(recipe.B)">
-                                    {{ data.index[recipe.B][0] }}&nbsp;{{ data.index[recipe.B][1] }}
-                                </td>
-                                <td>=</td>
-                                <td class="item" :class="{'item-used': !saveData.includes(recipe.C)}"
-                                    @click="navigateTo(recipe.C)">
-                                    {{ data.index[recipe.C][0] }}&nbsp;{{ data.index[recipe.C][1] }}
-                                </td>
-                            </tr>
-                        </table>
+                                <tr v-for="recipe in currentHiddenTo" v-if="showHiddenRecipes">
+                                    <td class="item" :class="{'item-used': !saveData.includes(recipe.A)}"
+                                        @click="navigateTo(recipe.A); slideTransition='slide-left';">
+                                        {{ data.index[recipe.A][0] }}&nbsp;{{ data.index[recipe.A][1] }}
+                                    </td>
+                                    <td>+</td>
+                                    <td class="item" :class="{'item-used': !saveData.includes(recipe.B)}"
+                                        @click="navigateTo(recipe.B); slideTransition='slide-left';">
+                                        {{ data.index[recipe.B][0] }}&nbsp;{{ data.index[recipe.B][1] }}
+                                    </td>
+                                    <td>=</td>
+                                    <td class="item" :class="{'item-used': !saveData.includes(recipe.C)}"
+                                        @click="navigateTo(recipe.C); slideTransition='slide-left';">
+                                        {{ data.index[recipe.C][0] }}&nbsp;{{ data.index[recipe.C][1] }}
+                                    </td>
+                                </tr>
+                            </table>
 
+                        </transition>
                         <div v-if="currentHiddenTo.length > 0">
                             <div v-if="!showHiddenRecipes" class="text-link" @click="showHiddenRecipes = true">
                                 {{currentHiddenTo.length}} entries hidden
@@ -170,16 +202,16 @@
                     </div>
                 </div>
             </div>
-            <div v-else style="display: flex; flex-direction: column; align-items: center;">
-                <input class="search-bar" type="text" placeholder="Search..." v-model="searchQuery"></input>
+            <div key=1 v-else>
                 <div style="display: flex; flex-wrap: wrap; justify-content: center;">
-                    <div v-if="Object.keys(data.data).length == 0" style="font-weight: bold;">Loading data...</div>
-                    <div class="item" :class="{'item-used': !saveData.includes(element)}"
-                        v-for="element in elementList" @click="navigateTo(element)">
+                    <div v-if="Object.keys(data.data).length == 0" style="font-weight: bold; padding-top: 5px;">Loading data...</div>
+                    <div class="item" :class="{'item-used': !saveData.includes(element)}" v-for="element in elementList"
+                        @click="navigateTo(element)">
                         {{ data.index[element][0] }}&nbsp;{{ data.index[element][1] }}
                     </div>
                 </div>
             </div>
+            </transition>
             <div id="scroll-end"></div>
         </div>
     </div>
@@ -231,7 +263,9 @@
 
         function generateData(raw) {
             let data = {}
+            let recipeCount = 0;
             for (let recipe of raw.data.split(";").map(x => x.split(","))) {
+                recipeCount++;
                 data[recipe[0]] ??= { from: [], to: [] }
                 data[recipe[0]].to.push([recipe[1], recipe[2]])
                 data[recipe[1]] ??= { from: [], to: [] }
@@ -239,7 +273,12 @@
                 data[recipe[2]] ??= { from: [], to: [] }
                 data[recipe[2]].from.push([recipe[0], recipe[1]])
             }
-            return { index: Object.fromEntries(Object.entries(raw.index).map(x => [x[0], [x[1][0], x[1][1]]])), costs: Object.fromEntries(Object.entries(raw.index).map(x => [x[0], x[1][2]])), data: data }
+            return {
+                index: Object.fromEntries(Object.entries(raw.index).map(x => [x[0], [x[1][0], x[1][1]]])),
+                costs: Object.fromEntries(Object.entries(raw.index).map(x => [x[0], x[1][2]])),
+                data: data,
+                recipeCount: recipeCount
+            };
         }
 
         function setQuery(query) {
@@ -271,13 +310,14 @@
         const app = new Vue({
             el: '#app',
             data: {
-                data: { index: {}, costs: {}, data: {} },
+                data: { index: {}, costs: {}, data: {}, recipeCount: 0 },
                 currentElement: "",
                 showHiddenRecipes: false,
                 searchQuery: "",
                 showToast: true,
                 saveData: [],
-                loaded: 1000
+                loaded: 1000,
+                slideTransition: "slide-right",
             },
             computed: {
                 currentTo: function () {

--- a/styles.css
+++ b/styles.css
@@ -27,6 +27,30 @@ body {
     border: 1px solid #525252;
 }
 
+table {
+    display: block;
+}
+
+.item-wrapper  {
+    flex-direction: row;
+    display: flex;
+    align-items: center;
+}
+
+.item-text {
+    display: inline-block;
+    overflow-wrap: break-word;
+}
+
+.item-emoji {
+    /*white-space: nowrap;*/
+}
+
+.table-cell {
+    display: flex;
+	justify-content: center;
+}
+
 .showUnavailableElements .item.item-used {
     filter: brightness(50%)
 }

--- a/styles.css
+++ b/styles.css
@@ -1,3 +1,7 @@
+:root {
+    color-scheme: dark;
+}
+
 body {
     font-family: "Roboto", sans-serif;
     width: 100vw;
@@ -77,6 +81,12 @@ body {
     color: #c6c7c7;
 }
 
+.search-bar-wrapper {
+    display: flex;
+    flex-direction: column;
+    align-items: center;
+}
+
 @media (max-width: 900px) {
     .ingredients-flex {
         flex-direction: column;
@@ -135,6 +145,12 @@ body {
     text-decoration: none;
 }
 
+.sub-header {
+    text-align: center; 
+    margin-top: 4px; 
+    color: gray;
+}
+
 @media (max-width: 800px) {
     .github-link-text {
         display: none
@@ -155,4 +171,40 @@ body {
         position: static;
         margin: 0
     }
+}
+
+.slide-up-enter-active,
+.slide-up-leave-active {
+  transition: all 0.12s;
+}
+
+.slide-up-enter, 
+.slide-up-leave-to {
+    opacity: 0;
+    transform: translateY(30px);
+}
+
+.slide-up-leave-from,
+.slide-left-leave-from,
+.slide-right-leave-from {
+  opacity: 0;
+}
+
+.slide-left-enter-active,
+.slide-left-leave-active,
+.slide-right-enter-active,
+.slide-right-leave-active {
+  transition: all 0.08s ease;
+}
+
+.slide-side-enter,
+.slide-right-leave-to {
+    opacity: 0;
+    transform: translateX(10px);
+}
+
+.slide-left-leave-to,
+.slide-right-enter {
+    opacity: 0;
+    transform: translateX(-10px);
 }


### PR DESCRIPTION
## Overview

Cleaned up a few visual elements, added a subheader to display the number of elements and recipes.
![image](https://github.com/expitau/InfiniteCraftWiki/assets/22671898/816104ae-9b21-4260-bbaa-db842f428d2d)

Made the search bar persistent which helps with quick navigation.
![image](https://github.com/expitau/InfiniteCraftWiki/assets/22671898/a28afb1d-0be6-4b0f-88cd-41461a4debfd)

## Additional changes
- Added some simple vue slide/fade transitions between pages and selected elements. They make the site feel more polished and jazzy, and take advantage of the fact that it is a one page site without being too in your face.