### PR TITLE
quick change to scroll to the top whenever you click on a link

### DIFF
--- a/web/index.html
+++ b/web/index.html
@@ -398,6 +398,11 @@
                     this.currentElement = element;
                     this.loaded = 1000
                     this.loadedElements = 100
+                    window.scroll({
+                        top: 0, 
+                        left: 0,
+                        behavior: 'smooth' 
+                    });
                     return this.currentElement ? this.currentElement : "";
                 },
                 addScrollPage: function () {


### PR DESCRIPTION
Whenever you click on a new element, then it should scroll back to the top of the page, since now that we have so so so many elements most of the time if you click on something you are just in the middle of an enormous list, maybe very far down or at the end of the page you just navigated to, and that isn't a great user experience 