### PR TITLE
Scale ingredients list if device is too small

### DIFF
--- a/web/style.css
+++ b/web/style.css
@@ -63,6 +63,23 @@ body {
     height: min-content;
 }
 
+
+@media (max-width: 520px) {
+    .ingredients-list {
+        scale: 0.9;
+        transform-origin: top;
+    }
+}
+
+@media (max-width: 460px) {
+    .ingredients-list {
+        scale: 0.8;
+        transform-origin: top;
+    }
+}
+
+
+
 @media (max-width) {
     #element {
         flex-direction: column-reverse


### PR DESCRIPTION
Until now, viewing the ingredients lists on mobile has sometimes not always looked the best because lists with wider elements sometimes had parts clipped on each side
![image](https://github.com/expitau/InfiniteCraftWiki/assets/22671898/0f19918c-89a0-4f1f-a486-a950001506a8)
This fixes it by scaling down the ingredients list by fixed percentages if the screen is smaller than the minimum size required to properly display all elements:
![image](https://github.com/expitau/InfiniteCraftWiki/assets/22671898/5a86750f-3dde-404a-9ad5-a60ea168d2ef)
