### PR TITLE
Fix recipes that cut off the result at the comma

### DIFF
--- a/tools/diff.js
+++ b/tools/diff.js
@@ -17,7 +17,7 @@ async function main() {
         }
     }
     for (let item of attemptedSet2) {
-        recipe = item.split(",,").map(x => data1.icons[x] + " " + x)
+        recipe = item.split(",,").map(x => data2.icons[x] + " " + x)
         console.log("\x1b[32m+",recipe[0],"+",recipe[1],"=>",recipe[2])
     }
     console.log(data1.attempted.length, data2.attempted.length)


### PR DESCRIPTION
This addresses item 2 from #19
I also updated some recipes that used to result in `Nothing`, but now result in something.
I did not include the changes I had to make to craft.js to fix crafting again

I believe the remaining differences between our databases are all because of censored items (#18). I would like to know your stance on this before I do anything with them. Do you want to keep the censored items, or remove them?

I plan on adding more recipes after this is merged.